### PR TITLE
chore: add issue and pull request templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,40 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: bug, triage
+assignees: ''
+
+---
+
+<!--- Provide a general summary of the issue in the Title above -->
+<!--- How has this issue affected you? What are you trying to accomplish? -->
+
+**What were you trying to accomplish?**
+
+## Expected Behavior
+<!--- If you're describing a bug, tell us what should happen -->
+<!--- If you're suggesting a change/improvement, tell us how it should work -->
+
+## Current Behavior
+<!--- If describing a bug, tell us what happens instead of the expected behavior -->
+<!--- If suggesting a change/improvement, explain the difference from current behavior -->
+
+## Possible Solution
+<!--- Not obligatory, but suggest a fix/reason for the bug, -->
+<!--- or ideas how to implement the addition or change -->
+
+## Steps to Reproduce (for bugs)
+<!--- Provide a link to a live example, or an unambiguous set of steps to -->
+<!--- reproduce this bug. Include code to reproduce, if relevant -->
+
+1.
+2.
+3.
+4.
+
+## Environment
+
+* **SAM Patterns CLI version**:
+* **Node version**:
+* **NPM version**:

--- a/.github/ISSUE_TEMPLATE/documentation-improvements.md
+++ b/.github/ISSUE_TEMPLATE/documentation-improvements.md
@@ -1,0 +1,17 @@
+---
+name: Documentation improvements
+about: Suggest a documentation update
+title: ''
+labels: documentation
+assignees: ''
+
+---
+
+**What were you initially searching for in the docs?**
+<!-- Please help us understand how you looked for information that was either not available or unclear -->
+
+**Is this related to an existing part of the documentation? Please share a link or excerpt**
+
+**Describe how we could make it clearer**
+
+**If you have a proposed update, please share it here**

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,20 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: ''
+labels: feature-request, triage
+assignees: ''
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+<!-- A clear and concise description of what the problem is. Ex. I'm always frustrated when [...] -->
+
+**Describe the solution you'd like**
+<!-- A clear and concise description of what you want to happen. -->
+
+**Describe alternatives you've considered**
+<!-- A clear and concise description of any alternative solutions or features you've considered. -->
+
+**Additional context**
+<!-- Add any other context or screenshots about the feature request here. -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,14 @@
+**Issue #, if available:**
+
+## Description of changes:
+
+<!--- One or two sentences as a summary of what's being changed -->
+
+## Checklist
+
+<!--- Leave unchecked if your change doesn't seem to apply --> 
+
+* [ ] Update tests
+* [ ] Update docs
+
+By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


### PR DESCRIPTION
Hey Lars, as we've discussed in the DevAx Connect live stream today, this PR adds sample templates to capture bug reports, documentation improvements, feature requests, and Pull Request body template