### PR TITLE
feat: add node16.x to runtimes

### DIFF
--- a/src/shared/runtimes.json
+++ b/src/shared/runtimes.json
@@ -16,11 +16,34 @@
     "languageName": "JavaScript",
     "extension": ".js",
     "handlerFormat": "filename.handler",
-    "latest": true,
     "sharable": true
   },
   {
     "name": "nodejs14.x",
+    "languageName": "TypeScript",
+    "extension": ".ts",
+    "handlerFormat": "filename.handler",
+    "sharable": true,
+    "metadataPromptTitle": "Please set esbuild configuration. Leave blank for defaults. Note that TypeScript support in SAM is in preview and can change without warning.",
+    "metadata": {
+      "BuildMethod": "esbuild",
+      "Properties": {
+        "Minify": { "Default": "true", "Prompt": true },
+        "Target": { "Default": "es2020", "Prompt": true },
+        "SourceMap": { "Default": "true", "Prompt": true }
+      }
+    }
+  },
+  {
+    "name": "nodejs16.x",
+    "languageName": "JavaScript",
+    "extension": ".js",
+    "handlerFormat": "filename.handler",
+    "latest": true,
+    "sharable": true
+  },
+  {
+    "name": "nodejs16.x",
     "languageName": "TypeScript",
     "extension": ".ts",
     "handlerFormat": "filename.handler",
@@ -31,7 +54,7 @@
       "BuildMethod": "esbuild",
       "Properties": {
         "Minify": { "Default": "true", "Prompt": true },
-        "Target": { "Default": "es2020", "Prompt": true },
+        "Target": { "Default": "es2021", "Prompt": true },
         "SourceMap": { "Default": "true", "Prompt": true }
       }
     }


### PR DESCRIPTION
**Issue #, if available:**

## Description of changes:

Adds node16.x to runtimes since it's now supported by lambdas.

## Checklist

* [ ] Update tests
* [ ] Update docs

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
